### PR TITLE
Kernel32.SYSTEM_INFO: Correct incorrect struct member.

### DIFF
--- a/PInvoke/Kernel32/SysInfoApi.cs
+++ b/PInvoke/Kernel32/SysInfoApi.cs
@@ -2311,7 +2311,7 @@ namespace Vanara.PInvoke
 			/// <summary>A pointer to the highest memory address accessible to applications and DLLs.</summary>
 			public IntPtr lpMaximumApplicationAddress;
 			/// <summary>A mask representing the set of processors configured into the system. Bit 0 is processor 0; bit 31 is processor 31.</summary>
-			public uint dwActiveProcessorMask;
+			public IntPtr dwActiveProcessorMask;
 			/// <summary>The number of logical processors in the current group. To retrieve this value, use the <c>GetLogicalProcessorInformation</c> function.</summary>
 			public uint dwNumberOfProcessors;
 			/// <summary>


### PR DESCRIPTION
| Name                                            | About                                                                                             |
|-------------------------------------------------|---------------------------------------------------------------------------------------------------|
| SYSTEM_INFO of Kernel32 is incorrectly defined. | Incorrect definition of the SYSTEM_INFO structure causes it to return incorrect data in x64 mode. |

**Describe the bug**
The SYSTEM_INFO structure is incorrectly defined whereby the `dwActiveProcessorMask` member of the structure is defined as an unsigned integer rather than a pointer type as otherwise seen on [MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/ns-sysinfoapi-_system_info).

This causes the data of the remaining members structure to be incorrectly set in non-32bit architectures.

**Original Erroneous Behaviour**
Ran in an empty project under X64 compilation mode.
![](https://i.imgur.com/ekNcpFR.png)

The incorrect behaviour should be easy to spot as the `dwProcessorType` is an invalid number (not in any documentation) and default `dwAllocationGranularity` should be 64K on this machine inside any process.

**Corrected Behaviour (Post Patch)**
Ran in an empty project under X64 compilation mode.
![](https://i.imgur.com/crPTBeK.png)