### PR TITLE
Fixed memory leaks when using WindowsIdentity.GetCurrent()

### DIFF
--- a/BITS/BackgroundCopyManager.cs
+++ b/BITS/BackgroundCopyManager.cs
@@ -134,7 +134,10 @@ namespace Vanara.IO
 		/// <summary>Checks if the current user has administrator rights.</summary>
 		internal static bool IsCurrentUserAdministrator()
 		{
-			var wp = new WindowsPrincipal(WindowsIdentity.GetCurrent());
+			using var identity = WindowsIdentity.GetCurrent();
+
+			var wp = new WindowsPrincipal(identity);
+
 			return wp.IsInRole(WindowsBuiltInRole.Administrator);
 		}
 

--- a/PInvoke/Security/AdvApi32/PSID.cs
+++ b/PInvoke/Security/AdvApi32/PSID.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using Vanara.Extensions;
 using Vanara.InteropServices;
 using static Vanara.PInvoke.Kernel32;
@@ -54,7 +55,15 @@ namespace Vanara.PInvoke
 
 			/// <summary>Gets the SID for the current user</summary>
 			/// <value>The current user's SID.</value>
-			public static SafePSID Current => new SafePSID(System.Security.Principal.WindowsIdentity.GetCurrent().User);
+			public static SafePSID Current
+			{
+				get
+				{
+					using var identity = WindowsIdentity.GetCurrent();
+
+					return new SafePSID(identity.User);
+				}
+			}
 
 			/// <summary>A SID representing the Everyone Group (S-1-1-0).</summary>
 			public static SafePSID Everyone => CreateWellKnown(WELL_KNOWN_SID_TYPE.WinWorldSid);

--- a/Security/AccessControl/SystemSecurity.cs
+++ b/Security/AccessControl/SystemSecurity.cs
@@ -308,7 +308,17 @@ namespace Vanara.Security.AccessControl
 			/// <param name="userName">Name of the user.</param>
 			public AccountPrivileges(SystemSecurity parent, string userName = null)
 			{
-				ctrl = parent; user = userName ?? WindowsIdentity.GetCurrent().Name;
+				ctrl = parent;
+
+				if (!string.IsNullOrEmpty(userName))
+					user = userName;
+
+				else
+				{
+					using var identity = WindowsIdentity.GetCurrent();
+
+					user = identity.Name;
+				}
 			}
 
 			/// <summary>Gets or sets the enablement of the specified privilege.</summary>
@@ -356,7 +366,18 @@ namespace Vanara.Security.AccessControl
 			/// <param name="userName">Name of the user.</param>
 			public LogonRights(SystemSecurity parent, string userName = null)
 			{
-				ctrl = parent; user = userName ?? WindowsIdentity.GetCurrent().Name;
+				ctrl = parent;
+
+				if (!string.IsNullOrEmpty(userName))
+					user = userName;
+
+				else
+				{
+					using var identity = WindowsIdentity.GetCurrent();
+
+					user = identity.Name;
+				}
+
 			}
 
 			/// <summary>Gets the logon rights for the current user.</summary>

--- a/UnitTests/BITS/JobPropTest.cs
+++ b/UnitTests/BITS/JobPropTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Security.Principal;
 
 namespace Vanara.IO.Tests
 {
@@ -89,7 +90,9 @@ namespace Vanara.IO.Tests
 			Assert.That(() => job.OnDemand = true, Throws.Nothing);
 			Assert.That(job.OnDemand, Is.EqualTo(true));
 
-			Assert.That(job.Owner, Is.EqualTo(System.Security.Principal.WindowsIdentity.GetCurrent().User));
+
+			using var identity = WindowsIdentity.GetCurrent();
+			Assert.That(job.Owner, Is.EqualTo(identity.User));
 
 			Assert.That(job.OwnerIntegrityLevel, Is.EqualTo(8192));
 

--- a/UnitTests/PInvoke/NetApi32/NetApi32Tests.cs
+++ b/UnitTests/PInvoke/NetApi32/NetApi32Tests.cs
@@ -149,7 +149,10 @@ namespace Vanara.PInvoke.Tests
 			Assert.That(() => e.First(i => i.lgrpi0_name == val), Throws.Nothing);
 			var info = NetLocalGroupGetInfo<LOCALGROUP_INFO_1>(null, val);
 			Assert.That(info.lgrpi1_name, Is.EqualTo(val));
-			var sidmem = new SafeHGlobalHandle(System.Security.Principal.WindowsIdentity.GetCurrent().User.GetBytes());
+
+			using var identity = WindowsIdentity.GetCurrent();
+			var sidmem = new SafeHGlobalHandle(identity.User.GetBytes());
+
 			NetLocalGroupAddMembers(null, val, new[] { new LOCALGROUP_MEMBERS_INFO_0 { lgrmi0_sid = (IntPtr)sidmem } });
 			var m = NetLocalGroupGetMembers<LOCALGROUP_MEMBERS_INFO_3>(null, val);
 			Assert.That(m, Is.Not.Empty);

--- a/UnitTests/PInvoke/Security/AdvApi32/AuditTests.cs
+++ b/UnitTests/PInvoke/Security/AdvApi32/AuditTests.cs
@@ -17,7 +17,21 @@ namespace Vanara.PInvoke.Tests
 
 		public static IEnumerable<Guid> Categories => AuditEnumerateCategories();
 
-		public static SafePSID CurUserSid => pCurSid ?? (pCurSid = new SafePSID(WindowsIdentity.GetCurrent().User.GetBytes()));
+
+		public static SafePSID CurUserSid
+		{
+			get
+			{
+				if (null != pCurSid)
+					return pCurSid;
+
+
+				using var identity = WindowsIdentity.GetCurrent();
+
+				return pCurSid = new SafePSID(identity.User.GetBytes());
+			}
+		}
+
 
 		public static IEnumerable<PSID> PerUserPolicy => AuditEnumeratePerUserPolicy();
 
@@ -46,8 +60,11 @@ namespace Vanara.PInvoke.Tests
 		[Test()]
 		public void AuditComputeEffectivePolicyByTokenTest()
 		{
-			using (var hTok = new SafeHTOKEN(WindowsIdentity.GetCurrent().Token))
-				Assert.That(AuditComputeEffectivePolicyByToken(hTok, new[] { regAudit }), Is.Not.Empty);
+			using var identity = WindowsIdentity.GetCurrent();
+
+			using var hTok = new SafeHTOKEN(identity.Token);
+
+			Assert.That(AuditComputeEffectivePolicyByToken(hTok, new[] { regAudit }), Is.Not.Empty);
 		}
 
 		[Test]

--- a/UnitTests/Security/AccessControl/SystemSecurityTests.cs
+++ b/UnitTests/Security/AccessControl/SystemSecurityTests.cs
@@ -62,7 +62,11 @@ namespace Vanara.Security.AccessControl.Tests
 			using (ss = new SystemSecurity(SystemSecurity.DesiredAccess.LookupNames))
 			{
 				IList<SystemSecurity.SystemAccountInfo> sa = null;
-				Assert.That(() => sa = ss.GetAccountInfo(false, false, WindowsIdentity.GetCurrent().User, new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)), Throws.Nothing);
+
+				using var identity = WindowsIdentity.GetCurrent();
+
+				Assert.That(() => sa = ss.GetAccountInfo(false, false, identity.User, new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null)), Throws.Nothing);
+
 				foreach (var sai in sa)
 					TestContext.WriteLine($"{sai.SidType}:{sai.Name}");
 			}


### PR DESCRIPTION
Fixed #92