### PR TITLE
Add known folder 3D Objects

### DIFF
--- a/PInvoke/Shell32/ShObjIdl.IKnownFolder.cs
+++ b/PInvoke/Shell32/ShObjIdl.IKnownFolder.cs
@@ -430,6 +430,10 @@ namespace Vanara.PInvoke
 			[KnownFolderDetail("{D20BEEC4-5CA8-4905-AE3B-BF251EA09B53}")]
 			FOLDERID_NetworkFolder,
 
+			/// <summary>3D Objects</summary>
+			[KnownFolderDetail("{31C0DD25-9439-4F12-BF41-7FF4EDA38722}")]
+			FOLDERID_Objects3D,
+
 			/// <summary>Original Images</summary>
 			[KnownFolderDetail("{2C36C0AA-5812-4b87-BFD0-4CD0DFB19B39}")]
 			FOLDERID_OriginalImages,


### PR DESCRIPTION
There are others being returned on my pc by IKnownFolderManager.GetFolderIds that are not mentioned https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid.

CanonicalName, FolderId, ParsingName

Local Pictures : 0ddd015d-b06c-45d5-8c4c-f59713854639 : C:\Users\tonyh\OneDrive\Pictures
Local Videos : 35286a68-3c57-41a1-bbb1-0eae73d76c95 : C:\Users\tonyh\Videos
Captures : edc0fe71-98d8-4f4a-b920-c8dc133cb165 : C:\Users\tonyh\Videos\Captures
CameraRollLibrary : 2b20df75-1eda-4039-8097-38798227d5b7 : ::{031E4825-7B94-4DC3-B131-E946B44C8DD5}\CameraRoll.library-ms
ThisPCDesktopFolder : 754ac886-df64-4cba-86b5-f7fbf4fbcef5 : C:\Users\tonyh\OneDrive\Desktop
Local Music : a0c69a99-21c8-4671-8703-7934162fcf1d : C:\Users\tonyh\Music
Local Downloads : 7d83ee9b-2244-4e70-b1f5-5393042af1e4 : C:\Users\tonyh\Downloads
CryptoKeys : b88f4daa-e7bd-49a9-b74d-02885a5dc765 : C:\Users\tonyh\AppData\Roaming\Microsoft\Crypto
DpapiKeys : 10c07cd0-ef91-4567-b850-448b77cb37f9 : C:\Users\tonyh\AppData\Roaming\Microsoft\Protect
Local Documents : f42ee2d3-909f-4907-8871-4c22fc0bf756 : C:\Users\tonyh\OneDrive\Documents
ThisDeviceFolder : 1c2ac1dc-4358-4b6c-9733-af21156576f0 : ::{F8278C54-A712-415B-B593-B77A2BE0DDA9}
SystemCertificates : 54eed2e0-e7ca-4fdb-9148-0f4247291cfa : C:\Users\tonyh\AppData\Roaming\Microsoft\SystemCertificates
CredentialManager : 915221fb-9efe-4bda-8fd7-f78dca774f87 : C:\Users\tonyh\AppData\Roaming\Microsoft\Credentials