### PR TITLE
Uncap path length in EnumFindMethods

### DIFF
--- a/PInvoke/Kernel32/WinBase.File.cs
+++ b/PInvoke/Kernel32/WinBase.File.cs
@@ -3177,7 +3177,7 @@ namespace Vanara.PInvoke
 		/// <returns>List of strings returned by <paramref name="first"/> and <paramref name="next"/> methods.</returns>
 		private static IEnumerable<string> EnumFindMethods<THandle>(FindFirstDelegate<THandle> first, FindNextDelegate<THandle> next, uint strSz = MAX_PATH + 1, uint done = Win32Error.ERROR_HANDLE_EOF) where THandle : SafeHandle
 		{
-			var sb = new StringBuilder((int)strSz, (int)strSz);
+			var sb = new StringBuilder((int)strSz);
 			THandle h;
 			while ((h = first(sb, ref strSz)).IsInvalid)
 			{


### PR DESCRIPTION
MAX_PATH is not a hard limit on the maximum length of a file path. Using Windows 10, I have a file path that is ~378 chars long, and an exception is thrown in the local method AddCap because the code attempts to increase the size of the StringBuilder beyond the 261 chars that was specified in the constructor. This change just removes the hard upper limit cap on that length.

(the misleading "Create WinBase.File.cs" commit name was caused by an issue with GitHub's web editor)