### PR TITLE
Support Windows 10 window-frame style

### DIFF
--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -213,7 +213,7 @@ namespace Vanara.Windows.Forms
 							using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\DWM"))
 							{
 								var prevalenceValue = key.GetValue("ColorPrevalence", null);
-								if (prevalenceValue != null && Convert.ToBoolean(prevalenceValue))
+								if (prevalenceValue is int i && Convert.ToBoolean(i))
 								{
 									// While this API does not return the *exact* shade used in title bars, its value
 									// is pretty close; certainly close enough to be useful for the below test.

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -158,9 +158,16 @@ namespace Vanara.Windows.Forms
 			return rect;
 		}
 
-		/// <summary>Raises the Paint event.</summary>
-		/// <param name="e">A <see cref="T:System.Windows.Forms.PaintEventArgs"/> that contains the event data.</param>
-		protected override void OnPaint(PaintEventArgs e)
+		/// <inheritdoc/>
+        protected override void OnSystemColorsChanged(EventArgs e)
+        {
+            base.OnSystemColorsChanged(e);
+			Invalidate(); // OnPaint() recalculates colors
+        }
+
+        /// <summary>Raises the Paint event.</summary>
+        /// <param name="e">A <see cref="T:System.Windows.Forms.PaintEventArgs"/> that contains the event data.</param>
+        protected override void OnPaint(PaintEventArgs e)
 		{
 			base.OnPaint(e);
 			if (!Visible) return;

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -220,6 +220,8 @@ namespace Vanara.Windows.Forms
 									DwmApi.DwmGetColorizationColor(out uint colorValue, out _).ThrowIfFailed();
 									Color color = Color.FromArgb((int)colorValue);
 
+									// These values were taken from here:
+									// https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color/3943023
 									if ((color.R * 0.299 + color.G * 0.587 + color.B * 0.114) > 186)
 										textColor = SystemColors.ControlText;
 									else

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -204,7 +204,7 @@ namespace Vanara.Windows.Forms
 					{
 						if (rtl == RightToLeft.Yes) tff |= TextFormatFlags.RightToLeft;
 
-						if (GlowingText && Environment.OSVersion.Version.Major == 10 && !SystemInformation.HighContrast)
+						if (GlowingText && Environment.OSVersion.Version.Major == 10 && !SystemInformation.HighContrast && !DesignMode)
                         {
 							Color textColor = SystemColors.ControlText;
 

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -159,15 +159,15 @@ namespace Vanara.Windows.Forms
 		}
 
 		/// <inheritdoc/>
-        protected override void OnSystemColorsChanged(EventArgs e)
-        {
-            base.OnSystemColorsChanged(e);
+		protected override void OnSystemColorsChanged(EventArgs e)
+		{
+			base.OnSystemColorsChanged(e);
 			Invalidate(); // OnPaint() recalculates colors
-        }
+		}
 
-        /// <summary>Raises the Paint event.</summary>
-        /// <param name="e">A <see cref="T:System.Windows.Forms.PaintEventArgs"/> that contains the event data.</param>
-        protected override void OnPaint(PaintEventArgs e)
+		/// <summary>Raises the Paint event.</summary>
+		/// <param name="e">A <see cref="T:System.Windows.Forms.PaintEventArgs"/> that contains the event data.</param>
+		protected override void OnPaint(PaintEventArgs e)
 		{
 			base.OnPaint(e);
 			if (!Visible) return;
@@ -205,7 +205,7 @@ namespace Vanara.Windows.Forms
 						if (rtl == RightToLeft.Yes) tff |= TextFormatFlags.RightToLeft;
 
 						if (GlowingText && Environment.OSVersion.Version.Major == 10 && !SystemInformation.HighContrast && !DesignMode)
-                        {
+						{
 							Color textColor = SystemColors.ControlText;
 
 							// SystemColors.ActiveCaption always returns an ugly shade of blue. SystemColors.ActiveCaptionText returns black.
@@ -215,7 +215,7 @@ namespace Vanara.Windows.Forms
 							{
 								var prevalenceValue = key.GetValue("ColorPrevalence", null);
 								if (prevalenceValue != null && Convert.ToBoolean(prevalenceValue))
-                                {
+								{
 									// While this API does not return the *exact* shade used in title bars, its value
 									// is pretty close; certainly close enough to be useful for the below test.
 									DwmApi.DwmGetColorizationColor(out uint colorValue, out _).ThrowIfFailed();
@@ -226,7 +226,7 @@ namespace Vanara.Windows.Forms
 									else
 										textColor = Color.White;
 								}
-                                else
+								else
 								{
 									// If we get here, then "Show accent color on title bars" has been disabled in Settings.
 									if (Form.ActiveForm.Equals(FindForm())) textColor = SystemColors.ControlText;

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -218,7 +218,7 @@ namespace Vanara.Windows.Forms
 									// While this API does not return the *exact* shade used in title bars, its value
 									// is pretty close; certainly close enough to be useful for the below test.
 									DwmApi.DwmGetColorizationColor(out uint colorValue, out _).ThrowIfFailed();
-									Color color = Color.FromArgb((int)colorValue);
+									Color color = Color.FromArgb(unchecked((int)colorValue));
 
 									// These values were taken from here:
 									// https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color/3943023

--- a/Windows.Forms/Controls/ThemedLabel.cs
+++ b/Windows.Forms/Controls/ThemedLabel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing;
-using System.Web.UI.Design.WebControls;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using Vanara.Extensions;


### PR DESCRIPTION
In Windows 10, DrawTextThemeEx() _never_ draws a glow, even when an explicit size is specified. Furthermore, all uxtheme APIs always return black for `SystemColors.ActiveCaptionText` (and `SystemColors.InactiveCaptionText`), no matter what function you call. I know of no public API that returns the exact colors of the window frame and frame text (which changes to white if the window frame color is dark enough, to ensure legibility). Therefore, I must approximate the effect by calling `DwmGetColorizationColor()` and manually changing the color given to DrawThemeTextEx().

This code will only take effect if running on Windows 10 (so Vanara will still follow the Windows 7 theme if run on Windows 7), and only if `GlowingText` is enabled. I used this property because glowing text and color-changing text have similar semantic purposes: to ensure visibility of text on a glowing or dark-colored background. If the user did not want the text to glow (for some reason), I don't think they would want it to change color on them unexpectedly either. While this design might result in unexpected white-on-light-color text if used in the window body, I do not believe that anyone will actually put a ThemedLabel into the window body, as that is not what it is designed to do.