### PR TITLE
Fixing wrong size of IMAGEHLP_MODULE64.ModuleName

### DIFF
--- a/PInvoke/DbgHelp/DbgHelp.Structs.cs
+++ b/PInvoke/DbgHelp/DbgHelp.Structs.cs
@@ -1164,7 +1164,7 @@ namespace Vanara.PInvoke
 			public SYM_TYPE SymType;
 
 			/// <summary>The module name.</summary>
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
 			public string ModuleName;
 
 			/// <summary>The image name. The name may or may not contain a full path.</summary>


### PR DESCRIPTION
While working with SymGetModuleInfoW64() I found that most fields of IMAGEHLP_MODULE64 were invalid/empty. This is due to the wrong ModuleName array size in Vanara's IMAGEHLP_MODULE64 struct definition. See here for the documented struct definition: https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-imagehlp_modulew64