### PR TITLE
SetTypeFlags parameter TYPEFLAGS changed to uint

### DIFF
--- a/PInvoke/Ole/OleAut32/OAIdl.Interfaces.cs
+++ b/PInvoke/Ole/OleAut32/OAIdl.Interfaces.cs
@@ -249,7 +249,7 @@ namespace Vanara.PInvoke
 			/// </returns>
 			// https://docs.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-icreatetypeinfo-settypeflags HRESULT SetTypeFlags(UINT uTypeFlags);
 			[PreserveSig]
-			HRESULT SetTypeFlags([MarshalAs(UnmanagedType.U4)] System.Runtime.InteropServices.ComTypes.TYPEFLAGS uTypeFlags);
+			HRESULT SetTypeFlags(uint uTypeFlags);
 
 			/// <summary>Sets the documentation string displayed by type browsers.</summary>
 			/// <param name="pStrDoc">A brief description of the type description.</param>
@@ -1197,7 +1197,7 @@ namespace Vanara.PInvoke
 			/// </returns>
 			// https://docs.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-icreatetypeinfo-settypeflags HRESULT SetTypeFlags(UINT uTypeFlags);
 			[PreserveSig]
-			new HRESULT SetTypeFlags([MarshalAs(UnmanagedType.U4)] System.Runtime.InteropServices.ComTypes.TYPEFLAGS uTypeFlags);
+			new HRESULT SetTypeFlags(uint uTypeFlags);
 
 			/// <summary>Sets the documentation string displayed by type browsers.</summary>
 			/// <param name="pStrDoc">A brief description of the type description.</param>


### PR DESCRIPTION
```
Exception has occurred: CLR/System.Runtime.InteropServices.MarshalDirectiveException
...Invalid managed/unmanaged type combination (Int16/UInt16 must be paired with I2 or U2).'
at System.StubHelpers.StubHelpers.ThrowInteropParamException(Int32 resID, Int32 paramIdx)
```

Regarding to the Microsoft documentation the method signature should looks like:

```
HRESULT SetTypeFlags(
  [in] UINT uTypeFlags
);
```

<https://docs.microsoft.com/en-us/windows/win32/api/oaidl/nf-oaidl-icreatetypeinfo-settypeflags>

TYPEFLAGS is U2 (2 Byte) but SetTypeFlags requires a U4 (4 Byte).

