### PR TITLE
Fix POINTER_INPUT_TYPE missing initial value

### DIFF
--- a/PInvoke/User32/WinUser.Pointer.cs
+++ b/PInvoke/User32/WinUser.Pointer.cs
@@ -285,19 +285,19 @@ namespace Vanara.PInvoke
 			/// caller to restrict the query to specific pointer type. The PT_POINTER type can be used in these functions to specify that
 			/// the query is to include pointers of all types
 			/// </summary>
-			PT_POINTER,
+			PT_POINTER = 1,
 
 			/// <summary>Touch pointer type.</summary>
-			PT_TOUCH,
+			PT_TOUCH = 2,
 
 			/// <summary>Pen pointer type.</summary>
-			PT_PEN,
+			PT_PEN = 3,
 
 			/// <summary>Mouse pointer type.</summary>
-			PT_MOUSE,
+			PT_MOUSE = 4,
 
 			/// <summary>Touchpad pointer type (Windows 8.1 and later).</summary>
-			PT_TOUCHPAD,
+			PT_TOUCHPAD = 5,
 		}
 
 		/// <summary>Values that can appear in the touchFlags field of the POINTER_TOUCH_INFO structure.</summary>


### PR DESCRIPTION
According to MSDN: [tagPOINTER_INPUT_TYPE enumeration (winuser.h)](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ne-winuser-tagpointer_input_type) , the POINTER_INPUT_TYPE enum's value is starting at 1.
But in the code, it missing the initial value, which makes its value from starting at 0 by default.