### PR TITLE
Add high resolution flag for waitable timer initialisation

### DIFF
--- a/PInvoke/Kernel32/SynchApi.cs
+++ b/PInvoke/Kernel32/SynchApi.cs
@@ -98,6 +98,9 @@ namespace Vanara.PInvoke
 
 			/// <summary>The timer must be manually reset.</summary>
 			CREATE_WAITABLE_TIMER_MANUAL_RESET = 0x00000001,
+
+            /// <summary>Creates a high resolution timer.</summary>
+            CREATE_WAITABLE_TIMER_HIGH_RESOLUTION = 0x00000002,
 		}
 
 		/// <summary>Define the upper byte of the critical section SpinCount field.</summary>


### PR DESCRIPTION
As per https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerexw.