### PR TITLE
#371 Add Create method for types MONITORINFO and MONITORINFOEX

### DIFF
--- a/PInvoke/User32/WinUser.Monitor.cs
+++ b/PInvoke/User32/WinUser.Monitor.cs
@@ -514,6 +514,7 @@ namespace Vanara.PInvoke
 		/// <para>
 		/// You must set the <c>cbSize</c> member of the structure to sizeof(MONITORINFO) or sizeof(MONITORINFOEX) before calling the
 		/// <c>GetMonitorInfo</c> function. Doing so lets the function determine the type of structure you are passing to it.
+		/// You can do this by calling <see cref="MONITORINFO.Create"/> to create new instance with properly set of <see cref="MONITORINFO.cbSize"/>.
 		/// </para>
 		/// <para>
 		/// The MONITORINFOEX structure is a superset of the MONITORINFO structure. It has one additional member: a string that contains a
@@ -543,6 +544,7 @@ namespace Vanara.PInvoke
 		/// <para>
 		/// You must set the <c>cbSize</c> member of the structure to sizeof(MONITORINFO) or sizeof(MONITORINFOEX) before calling the
 		/// <c>GetMonitorInfo</c> function. Doing so lets the function determine the type of structure you are passing to it.
+		/// You can do this by calling <see cref="MONITORINFOEX.Create"/> to create new instance with properly set of <see cref="MONITORINFOEX.cbSize"/>.
 		/// </para>
 		/// <para>
 		/// The MONITORINFOEX structure is a superset of the MONITORINFO structure. It has one additional member: a string that contains a
@@ -744,6 +746,21 @@ namespace Vanara.PInvoke
 			/// </list>
 			/// </summary>
 			public MonitorInfoFlags dwFlags;
+			
+			/// <summary>
+			/// Creates new instance of <see cref="MONITORINFOEX"/> structure 
+			/// </summary>
+			/// <returns>
+			/// Returns new instance of properly initialized <see cref="MONITORINFOEX"/> structure. 
+			/// </returns>
+			/// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFOEX)"/>
+			public static MONITORINFO Create()
+			{
+				return new MONITORINFO
+				{
+					cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFO))
+				};
+			}
 		}
 
 		/// <summary>
@@ -809,6 +826,21 @@ namespace Vanara.PInvoke
 			/// </summary>
 			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
 			public string szDevice;
+
+			/// <summary>
+			/// Creates new instance of <see cref="MONITORINFOEX"/> structure 
+			/// </summary>
+			/// <returns>
+			/// Returns new instance of properly initialized <see cref="MONITORINFOEX"/> structure. 
+			/// </returns>
+			/// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFOEX)"/>
+			public static MONITORINFOEX Create()
+			{
+				return new MONITORINFOEX
+				{
+					cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFOEX))
+				};
+			}
 		}
 	}
 }

--- a/PInvoke/User32/WinUser.Monitor.cs
+++ b/PInvoke/User32/WinUser.Monitor.cs
@@ -748,19 +748,16 @@ namespace Vanara.PInvoke
 			public MonitorInfoFlags dwFlags;
 			
 			/// <summary>
-			/// Creates new instance of <see cref="MONITORINFOEX"/> structure 
+			/// Creates new instance of <see cref="MONITORINFO"/> structure 
 			/// </summary>
 			/// <returns>
-			/// Returns new instance of properly initialized <see cref="MONITORINFOEX"/> structure. 
+			/// Returns new instance of properly initialized <see cref="MONITORINFO"/> structure. 
 			/// </returns>
-			/// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFOEX)"/>
-			public static MONITORINFO Create()
-			{
-				return new MONITORINFO
-				{
-					cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFO))
-				};
-			}
+			/// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFO)"/>
+            public static MONITORINFO Default => new()
+            {
+                cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFO))
+            };
 		}
 
 		/// <summary>
@@ -827,20 +824,17 @@ namespace Vanara.PInvoke
 			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
 			public string szDevice;
 
-			/// <summary>
-			/// Creates new instance of <see cref="MONITORINFOEX"/> structure 
-			/// </summary>
-			/// <returns>
-			/// Returns new instance of properly initialized <see cref="MONITORINFOEX"/> structure. 
-			/// </returns>
-			/// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFOEX)"/>
-			public static MONITORINFOEX Create()
-			{
-				return new MONITORINFOEX
-				{
-					cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFOEX))
-				};
-			}
-		}
+            /// <summary>
+            /// Creates new instance of <see cref="MONITORINFOEX"/> structure 
+            /// </summary>
+            /// <returns>
+            /// Returns new instance of properly initialized <see cref="MONITORINFOEX"/> structure. 
+            /// </returns>
+            /// <seealso cref="User32.GetMonitorInfo(Vanara.PInvoke.HMONITOR,ref Vanara.PInvoke.User32.MONITORINFOEX)"/>
+            public static MONITORINFOEX Default => new()
+            {
+                cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFOEX))
+            };
+        }
 	}
 }

--- a/UnitTests/PInvoke/User32/User32MonitorTests.cs
+++ b/UnitTests/PInvoke/User32/User32MonitorTests.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using static Vanara.PInvoke.User32;
+
+namespace Vanara.PInvoke.Tests
+{
+    [TestFixture()]
+    public partial class User32Tests
+    {
+        [Test]
+        public void EnumDisplayMonitorsTest()
+        {
+            var hdc = new HDC();
+            var monitors = new List<IntPtr>();
+            bool result = EnumDisplayMonitors(hdc, null, (monitor, _, _, _) =>
+            {
+                monitors.Add(monitor);
+                return true;
+            }, IntPtr.Zero);
+            
+            Assert.IsTrue(result, "Error calling EnumDisplayMonitors()");
+            Assert.IsNotEmpty(monitors, "Calling EnumDisplayMonitors() returns empty list");
+
+            TestContext.WriteLine($"EnumDisplayMonitors() returned {monitors.Count} monitor(s)");
+
+            var primaryDisplayHandle = IntPtr.Zero;
+            foreach (var monitor in monitors)
+            {
+                var info = MONITORINFOEX.Create();
+                bool getInfoResult = GetMonitorInfo(monitor, ref info);
+                Assert.IsTrue(getInfoResult, $"Error calling GetMonitorInfo(h: {monitor}) returned: {getInfoResult}");
+
+                Assert.IsFalse(info.rcMonitor.IsEmpty, $"Bounds of monitor(handle: {monitor}) are empty!");
+                
+                var isPrimary = (info.dwFlags & MonitorInfoFlags.MONITORINFOF_PRIMARY) != 0;
+                
+                TestContext.WriteLine(
+                    $"handle: {monitor}, name: {info.szDevice}, flags: {info.dwFlags}, isPrimary: {isPrimary}," +
+                    $" bounds: {info.rcMonitor}, workarea: {info.rcWork}");
+
+
+                if (isPrimary)
+                {
+                    if (primaryDisplayHandle == IntPtr.Zero)
+                    {
+                        primaryDisplayHandle = monitor;
+                    }
+                    else
+                    {
+                        Assert.Fail(
+                            $"Error calling GetMonitorInfo(h: {monitor}) returned flag that this monitor is primary, " +
+                            $"but there is already another monitor (handle: {primaryDisplayHandle}) with flag primary.");
+                    }
+                }
+            }
+            
+
+        }
+    }
+}

--- a/UnitTests/PInvoke/User32/User32MonitorTests.cs
+++ b/UnitTests/PInvoke/User32/User32MonitorTests.cs
@@ -38,8 +38,7 @@ namespace Vanara.PInvoke.Tests
                 TestContext.WriteLine(
                     $"handle: {monitor}, name: {info.szDevice}, flags: {info.dwFlags}, isPrimary: {isPrimary}," +
                     $" bounds: {info.rcMonitor}, workarea: {info.rcWork}");
-
-
+                
                 if (isPrimary)
                 {
                     if (primaryDisplayHandle == IntPtr.Zero)
@@ -54,8 +53,6 @@ namespace Vanara.PInvoke.Tests
                     }
                 }
             }
-            
-
         }
     }
 }

--- a/UnitTests/PInvoke/User32/User32MonitorTests.cs
+++ b/UnitTests/PInvoke/User32/User32MonitorTests.cs
@@ -27,7 +27,7 @@ namespace Vanara.PInvoke.Tests
             var primaryDisplayHandle = IntPtr.Zero;
             foreach (var monitor in monitors)
             {
-                var info = MONITORINFOEX.Create();
+                var info = MONITORINFOEX.Default;
                 bool getInfoResult = GetMonitorInfo(monitor, ref info);
                 Assert.IsTrue(getInfoResult, $"Error calling GetMonitorInfo(h: {monitor}) returned: {getInfoResult}");
 


### PR DESCRIPTION
- Created proposed `Create` methods for both types `MONITORINFO` and `MONITORINFOEX`
- Added new unit test file `User32MonitorTests.cs` with method `EnumDisplayMonitorsTest` to test methods `EnumDisplayMonitors` and `GetMonitorInfo`