### PR TITLE
Fixed incorrect definition on API DbgUiSetThreadDebugObject

### DIFF
--- a/PInvoke/NtDll/Winternl.cs
+++ b/PInvoke/NtDll/Winternl.cs
@@ -302,14 +302,6 @@ namespace Vanara.PInvoke
 
 		/// <summary>Set the debug object handle in the TEB. This function is UNDOCUMENTED.</summary>
 		/// <param name="DebugObjectHandle">Debug object handle. Retrieve from NtQueryInformationProcess</param>
-		/// <returns>
-		/// <para>The function returns an NTSTATUS success or error code.</para>
-		/// <para>
-		/// The forms and significance of NTSTATUS error codes are listed in the Ntstatus.h header file available in the DDK, and are
-		/// described in the DDK documentation under Kernel-Mode Driver Architecture / Design Guide / Driver Programming Techniques /
-		/// Logging Errors.
-		/// </para>
-		/// </returns>
 		[DllImport(Lib.NtDll, SetLastError = false, ExactSpelling = true)]
 		public static extern void DbgUiSetThreadDebugObject(IntPtr DebugObjectHandle);
 

--- a/PInvoke/NtDll/Winternl.cs
+++ b/PInvoke/NtDll/Winternl.cs
@@ -311,7 +311,7 @@ namespace Vanara.PInvoke
 		/// </para>
 		/// </returns>
 		[DllImport(Lib.NtDll, SetLastError = false, ExactSpelling = true)]
-		public static extern NTStatus DbgUiSetThreadDebugObject(IntPtr DebugObjectHandle);
+		public static extern void DbgUiSetThreadDebugObject(IntPtr DebugObjectHandle);
 
 		/// <summary>Call the kernel to remove the debug object. This function is UNDOCUMENTED.</summary>
 		/// <param name="ProcessHandle">The process handle.</param>

--- a/UnitTests/PInvoke/NtDll/WinternlTests.cs
+++ b/UnitTests/PInvoke/NtDll/WinternlTests.cs
@@ -84,7 +84,7 @@ namespace Vanara.PInvoke.Tests
 
 				try
 				{
-					Assert.That(DbgUiSetThreadDebugObject(DebugObjectHandleQueryResult.Value), ResultIs.Successful);
+					DbgUiSetThreadDebugObject(DebugObjectHandleQueryResult.Value);
 
 					try
 					{
@@ -114,7 +114,7 @@ namespace Vanara.PInvoke.Tests
 					}
 					finally
 					{
-						Assert.That(DbgUiSetThreadDebugObject(IntPtr.Zero), ResultIs.Successful);
+						DbgUiSetThreadDebugObject(IntPtr.Zero);
 					}
 				}
 				finally


### PR DESCRIPTION
DbgUiSetThreadDebugObject do not return any value, we should mark it as "void". See this screenshot from ReactOS.
Return NTStatus is not correct and might cause some issues.

![image](https://user-images.githubusercontent.com/42038175/230052408-24226547-f5fa-463f-8e58-fcc6d423a86f.png)
