### PR TITLE
undo [StructLayout.Pack = 8] removal at PROPVARIANT

### DIFF
--- a/PInvoke/Ole/Ole32/PropIdl.PROPVARIANT.cs
+++ b/PInvoke/Ole/Ole32/PropIdl.PROPVARIANT.cs
@@ -108,7 +108,7 @@ namespace Vanara.PInvoke
 		/// The middle three members are reserved for future use.
 		/// </para>
 		/// </summary>
-		[StructLayout(LayoutKind.Explicit)]
+		[StructLayout(LayoutKind.Explicit, Pack = 8)]
 		public sealed class PROPVARIANT : ICloneable, IComparable, IComparable<PROPVARIANT>, IDisposable, IEquatable<PROPVARIANT>
 		{
 			/// <summary>Value type tag.</summary>


### PR DESCRIPTION
Undo part of #413 : Return `[StructLayout.Pack = 8]` to `PROPVARIANT` as it [affects the layout regardless of the `LayoutKind`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.layoutkind?view=net-7.0#remarks)