### PR TITLE
Set HResult of exceptionForHR with message

### DIFF
--- a/UnitTests/PInvoke/Shared/WinError/HRESULTTests.cs
+++ b/UnitTests/PInvoke/Shared/WinError/HRESULTTests.cs
@@ -50,6 +50,10 @@ public class HRESULTTests
 		Assert.That(new HRESULT(HRESULT.CO_E_ATTEMPT_TO_CREATE_OUTSIDE_CLIENT_CONTEXT).GetException(), Is.TypeOf<COMException>());
 		Assert.That(new HRESULT(HRESULT.E_INVALIDARG).GetException(), Is.TypeOf<ArgumentException>());
 		Assert.That(new HRESULT(HRESULT.E_INVALIDARG).GetException("Bad"), Has.Message.EqualTo("Bad"));
+		#if NETCOREAPP3_0_OR_GREATER
+		var win32HResult = new Win32Error(Win32Error.ERROR_SHARING_VIOLATION).ToHRESULT();
+		Assert.That(win32HResult.GetException("Bad"), Has.Property(nameof(Exception.HResult)).EqualTo(win32HResult));
+		#endif
 	}
 
 	[Test()]


### PR DESCRIPTION
# Issue
When using `HRESULT.ThrowIfFailed` with a non-null message, the returned exception might not have the correct HResult value.

# Root Cause
When `HRESULT.GetException` is called with a non-null message, it creates a new exception with the same type as the exception from `Marshal.GetExceptionForHR`, expecting a constructor that takes a string message.

It does not set the HResult of this new exception.

# Fix
Set `HResult` of new exception