### PR TITLE
Update FwpTypes.cs (FWP_DATA_TYPE.FWP_SINGLE_DATA_TYPE_MAX enum value)

### DIFF
--- a/PInvoke/FwpUClnt/FwpTypes.cs
+++ b/PInvoke/FwpUClnt/FwpTypes.cs
@@ -198,7 +198,7 @@ public static partial class FwpUClnt
 		/// <para>0xff</para>
 		/// <para>Reserved for future use.</para>
 		/// </summary>
-		FWP_SINGLE_DATA_TYPE_MAX,
+		FWP_SINGLE_DATA_TYPE_MAX = 0xff,
 
 		/// <summary>
 		/// <para>Indicates a pointer to an</para>


### PR DESCRIPTION
Following to https://learn.microsoft.com/en-us/windows/win32/api/fwptypes/ne-fwptypes-fwp_data_type FWP_DATA_TYPE.FWP_SINGLE_DATA_TYPE_MAX has 0xff value, so i'm not able to create filter with FWP_V4_ADDR_MASK condition  value type.

When i try to create filter it gives me 'An FWP_VALUE or FWPM_CONDITION_VALUE is of the wrong type.' error.