### PR TITLE
Fix issue with plibNewPosition not set properly

### DIFF
--- a/Core/InteropServices/ComStream.cs
+++ b/Core/InteropServices/ComStream.cs
@@ -392,7 +392,7 @@ public class ComStream : Stream, IStream, IDisposable
 			// The enum values of SeekOrigin match the enum values of STREAM_SEEK, so we can just cast the dwOrigin to a SeekOrigin
 			var origin = Enum.IsDefined(typeof(SeekOrigin), dwOrigin) ? (SeekOrigin)dwOrigin : SeekOrigin.Begin;
 			var newPos = netStream.Seek(dlibMove, origin);
-			if (plibNewPosition == IntPtr.Zero)
+			if (plibNewPosition != IntPtr.Zero)
 				Marshal.WriteInt64(plibNewPosition, newPos);
 		}
 		else if (comStream is not null)


### PR DESCRIPTION
I believe the new position should be written if `plibNewPosition` is NOT `IntPtr.Zero`