### PR TITLE
Add CF_UPDATE_FLAG_ALWAYS_FULL & CF_UPDATE_FLAG_ALLOW_PARTIAL to CF_UPDATE_FLAGS

### DIFF
--- a/PInvoke/CldApi/cfapi.cs
+++ b/PInvoke/CldApi/cfapi.cs
@@ -1217,6 +1217,21 @@ public static partial class CldApi
 		/// filtering; otherwise, the platform skips setting any fields whose value is 0.
 		/// </summary>
 		CF_UPDATE_FLAG_PASSTHROUGH_FS_METADATA = 0x00000100,
+
+		/// <summary>
+		/// Effective on placeholder files only. Marks the placeholder always full.  
+		/// Once hydrated, any attempt to dehydrate will fail with
+		/// ERROR_CLOUD_FILE_DEHYDRATION_DISALLOWED.
+		/// </summary>
+		CF_UPDATE_FLAG_ALWAYS_FULL = 0x00000200,
+
+		/// <summary>
+		/// Effective on placeholder files only. Clears the always‑full state, allowing
+		/// dehydration again. Cannot be combined with CF_UPDATE_FLAG_ALWAYS_FULL; doing
+		/// so returns ERROR_CLOUD_FILE_INVALID_REQUEST.
+		/// </summary>
+		CF_UPDATE_FLAG_ALLOW_PARTIAL = 0x00000400,
+
 	}
 
 	/// <summary>Contains common callback information.</summary>


### PR DESCRIPTION
### Summary
Adds the two flags that were introduced after Windows 10 1709 but are still missing from Vanara’s **CF_UPDATE_FLAGS** enum.

| Constant | Value | Purpose |
|----------|-------|---------|
| `CF_UPDATE_FLAG_ALWAYS_FULL` | `0x00000200` | Marks a hydrated placeholder *always full*; future dehydration fails with `ERROR_CLOUD_FILE_DEHYDRATION_DISALLOWED`. |
| `CF_UPDATE_FLAG_ALLOW_PARTIAL` | `0x00000400` | Clears the *always‑full* state so the file can be dehydrated again (cannot be combined with the flag above). |

### Changes
* **PInvoke/CldApi/cfapi.cs** – appended the two constants with XML‑doc comments that mirror the Win32 docs.

### Motivation
Without these flags, consumers cannot control the *always full*/dehydration behavior added in newer Windows versions.

### References
* Win32 docs – *CF_UPDATE_FLAGS* (cfapi.h)  
  * <https://learn.microsoft.com/en-us/windows/win32/api/cfapi/ne-cfapi-cf_update_flags>